### PR TITLE
FIX #5 CFGenerator now can access comuni.txt from the jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ pom.xml.versionsBackup
 .idea
 *.iml
 .factorypath
+script
+

--- a/README.adoc
+++ b/README.adoc
@@ -18,6 +18,22 @@ $ cd vertx-cf
 $ mvn compile vertx:run
 ----
 
+
+== Running the Booster Locally ( from the fatjar )
+To run this booster on your local host from the jar:
+----
+$ git clone git@github.com:marinog82/vertx-cf
+
+$ cd vertx-cf
+
+$ mvn package 
+
+$ java  -cp . -jar target/booster-mission-runtime-<version>.jar -conf target/conf/application.json
+
+----
+
+
+
 == Interacting with the Booster Locally
 To interact with your booster while its running, use the form at `http://localhost:8080` or the `curl` command:
 
@@ -28,6 +44,12 @@ $ curl http://localhost:8080/api/greeting
 
 $ curl http://localhost:8080/api/greeting?name=Sarah
 {"content":"Hello, Sarah!"}
+
+$ curl http://localhost:8080/api/cf?cognome=Mondini&nome=Franco&comune=NOVELLARA&m=Aprile&anno=1982&giorno=22&sesso=M
+{
+  "content" : "MNDFNC82D22F960D"
+}
+
 ----
 
 == Running the Booster on a Single-node OpenShift Cluster

--- a/src/main/java/io/openshift/booster/CFGenerator.java
+++ b/src/main/java/io/openshift/booster/CFGenerator.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.Scanner;
 
 import java.io.File;
+import java.io.InputStream;
 import java.net.URL;
 
 class CFGenerator {
@@ -198,10 +199,8 @@ class CFGenerator {
   private String elaboraCodiceComune() {
   String cc="";
     try {
-      ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-      URL resource = classLoader.getResource("comuni.txt");
-      File file = new File(resource.getPath());
-      Scanner scanner = new Scanner(file);
+      InputStream in = getClass().getResourceAsStream("/comuni.txt");
+      Scanner scanner = new Scanner(in);//file);
       scanner.useDelimiter("\r\n");
       
       while(scanner.hasNext()) {


### PR DESCRIPTION
reference form the technique useful for the fix: https://macintoshnotes.wordpress.com/2016/02/20/accessing-resources-fomr-java-and-in-particular-from-a-jar/